### PR TITLE
Avoid collisions

### DIFF
--- a/rust-dlopen-derive/src/api.rs
+++ b/rust-dlopen-derive/src/api.rs
@@ -33,7 +33,7 @@ fn field_to_tokens(field: &Field) -> quote::Tokens {
             let raw_result = lib.ptr_or_null_cstr::<()>(
                 ::std::ffi::CStr::from_bytes_with_nul_unchecked(concat!(#symbol_name, "\0").as_bytes())
             );
-            dlopen::symbor::FromRawResult::from_raw_result(raw_result)?
+            ::dlopen::symbor::FromRawResult::from_raw_result(raw_result)?
         }
     }
 


### PR DESCRIPTION
The lack of "::" results "access to extern crates through prelude"
when the crate is used in lib.rs and the macro is used in somewhere
else.