### PR TITLE
Remove Outdated Note About Mac Bug

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,14 +12,3 @@ together with this project. It covers most types
 of exported symbols, therefor it allows you to check
 if the library actually obtains correctly all kinds 
 of symbols.
-
-**Note:** Rust has still a [**bug**](https://github.com/rust-lang/rust/issues/28794) that results in 
-generating invalid dynamic link libraries.
-On OSX you can expect to have a crash when the
-library gets unloaded. Please notice that this
-bug is related to building dynamic link libraries
- (in this case the example library), not to loading
- libraries.
- If you use rust-dlopen for working with correctly built
-dynamic link libraries, everything should work
-normally.


### PR DESCRIPTION
There was a note about a Mac bug with rust. The bug is fixed now, so there is no need for the note in the Readme.