### PR TITLE
Add functions for loading symbols from the program itself

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ I hope that this library will help you to quickly get what you need and avoid er
 | Overhead                           | Minimal    | Minimal    | **Some overhead** |
 | Low-level, unsafe API              | Yes        | Yes        | Yes       |
 | Object-oriented friendly           | Yes        | **No**       | Yes     |
+| Load from the program itself       | Yes        | **No**       | **No**  |
 
 ## Safety
 

--- a/src/raw/common.rs
+++ b/src/raw/common.rs
@@ -3,9 +3,9 @@ use std::ffi::{CStr, CString, OsStr};
 
 //choose the right platform implementation here
 #[cfg(unix)]
-use super::unix::{close_lib, get_sym, open_lib, Handle};
+use super::unix::{close_lib, get_sym, open_self, open_lib, Handle};
 #[cfg(windows)]
-use super::windows::{close_lib, get_sym, open_lib, Handle};
+use super::windows::{close_lib, get_sym, open_self, open_lib, Handle};
 
 use std::mem::{size_of, transmute_copy};
 
@@ -61,6 +61,17 @@ impl Library {
     {
         Ok(Self {
             handle: unsafe { open_lib(name.as_ref()) }?,
+        })
+    }
+    /**
+    Open the main program itself as a library.
+
+    This allows a shared library to load symbols of the program it was loaded
+    into.
+    */
+    pub fn open_self() -> Result<Library, Error> {
+        Ok(Self {
+            handle: unsafe { open_self() }?,
         })
     }
     /**

--- a/src/raw/windows.rs
+++ b/src/raw/windows.rs
@@ -4,7 +4,7 @@ use std::os::windows::ffi::OsStrExt;
 use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 use std::io::{Error as IoError, ErrorKind};
 use super::super::err::Error;
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 use std::ffi::{CStr, OsStr};
 use std::sync::Mutex;
 
@@ -123,6 +123,16 @@ pub unsafe fn get_sym(handle: Handle, name: &CStr) -> Result<*mut (), Error> {
         Err(Error::SymbolGettingError(get_win_error()))
     } else {
         Ok(symbol as *mut ())
+    }
+}
+
+#[inline]
+pub unsafe fn open_self() -> Result<Handle, Error> {
+    let mut handle: Handle = null_mut();
+    if kernel32::GetModuleHandleExW(0, null(), &mut handle) == 0 {
+        Err(Error::OpeningLibraryError(get_win_error()))
+    } else {
+        Ok(handle)
     }
 }
 

--- a/src/symbor/container.rs
+++ b/src/symbor/container.rs
@@ -62,6 +62,19 @@ where
         let api = T::load(static_ref)?;
         Ok(Self { api: api, lib: lib })
     }
+    ///Load all symbols from the program itself.
+    ///
+    /// This allows a shared library to load symbols of the program it was
+    /// loaded into.
+    pub unsafe fn load_self() -> Result<Self, Error> {
+        let lib = Library::open_self()?;
+        //this is cheating of course
+        //but it is safe because Library and api is placed in the same structure
+        //and therefore it is released at the same time.
+        let static_ref: &'static Library = transmute(&lib);
+        let api = T::load(static_ref)?;
+        Ok(Self { api: api, lib: lib })
+    }
 }
 
 impl<T> Deref for Container<T>

--- a/src/symbor/library.rs
+++ b/src/symbor/library.rs
@@ -55,6 +55,16 @@ impl Library {
         })
     }
 
+    /// Open the program itself as library.
+    ///
+    /// This allows a shared library to load symbols of the program it was
+    /// loaded into.
+    pub fn open_self() -> Result<Library, Error> {
+        Ok(Library {
+            lib: RawLib::open_self()?,
+        })
+    }
+
     /// Obtain a symbol from library.
     ///
     /// This method is the most general one and allows obtaining basically everything assuming

--- a/src/wrapper/container.rs
+++ b/src/wrapper/container.rs
@@ -69,6 +69,15 @@ where
         let api = T::load(&lib)?;
         Ok(Self { lib: lib, api: api })
     }
+    ///Load all symbols from the program itself.
+    ///
+    /// This allows a shared library to load symbols of the program it was
+    /// loaded into.
+    pub unsafe fn load_self() -> Result<Container<T>, Error> {
+        let lib = Library::open_self()?;
+        let api = T::load(&lib)?;
+        Ok(Self { lib: lib, api: api })
+    }
 }
 
 impl<T> Deref for Container<T>

--- a/src/wrapper/optional.rs
+++ b/src/wrapper/optional.rs
@@ -80,6 +80,19 @@ where
         let optional = Optional::load(&lib).ok();
         Ok(Self { lib, api, optional })
     }
+
+    ///Load all symbols (including optional if it is possible) from the
+    ///program itself.
+    ///
+    /// This allows a shared library to load symbols of the program it was
+    /// loaded into.
+    pub unsafe fn load_self() -> Result<OptionalContainer<Api, Optional>, Error> {
+        let lib = Library::open_self()?;
+        let api = Api::load(&lib)?;
+        let optional = Optional::load(&lib).ok();
+        Ok(Self { lib, api, optional })
+    }
+
     ///Gives access to the optional API - constant version.
     pub fn optional(&self) -> &Option<Optional> {
         return &self.optional;

--- a/src/wrapper/optional.rs
+++ b/src/wrapper/optional.rs
@@ -77,15 +77,8 @@ where
     {
         let lib = Library::open(name)?;
         let api = Api::load(&lib)?;
-        let optional = match Optional::load(&lib) {
-            Ok(val) => Some(val),
-            Err(_) => None,
-        };
-        Ok(Self {
-            lib: lib,
-            api: api,
-            optional: optional,
-        })
+        let optional = Optional::load(&lib).ok();
+        Ok(Self { lib, api, optional })
     }
     ///Gives access to the optional API - constant version.
     pub fn optional(&self) -> &Option<Optional> {


### PR DESCRIPTION
This is useful for shared libraries to load symbols from the program it was loaded into. (E.g. plugins.)