### PR TITLE
Rust 2018 + updated dependencies to newer stables + use of better handling of unsafe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ path = "rust-dlopen-derive"
 version = "0.1.4"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
+winapi = "0.3.7"
+kernel32-sys = "0.2.2"
 dbghelp-sys = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ version = "0.1.4"
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"
+dbghelp-sys = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,5 +67,9 @@ name = "wrapper_api"
 crate-type = ["bin"]
 
 [[example]]
+name = "raw_addr_info"
+crate-type = ["bin"]
+
+[[example]]
 name = "wrapper_multi_api"
 crate-type = ["bin"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "rust-dlopen-derive"
 version = "0.1.4"
 
 [target.'cfg(windows)'.dependencies]
-winapi = {version = "0.3.7", features=["winnt", "minwindef", "winerror", "libloaderapi", "errhandlingapi", "dbghelp", "processthreadsapi"]}
+winapi = {version = "0.3.7", features=["winnt", "minwindef", "winerror", "libloaderapi", "errhandlingapi", "dbghelp", "processthreadsapi", "basetsd"]}
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.29"

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate const_cstr;
-extern crate dlopen;
 extern crate libc;
 
 mod commons;

--- a/examples/raw_addr_info.rs
+++ b/examples/raw_addr_info.rs
@@ -1,0 +1,21 @@
+extern crate dlopen;
+extern crate libc;
+
+mod commons;
+
+use commons::{example_lib_path};
+use dlopen::raw::{Library, address_info};
+use libc::{c_int};
+
+fn main() {
+    let lib_path = example_lib_path();
+    let lib = Library::open(&lib_path).expect("Could not open library");
+    let c_fun_add_two: unsafe extern "C" fn(c_int) -> c_int =
+        unsafe { lib.symbol("c_fun_add_two") }.unwrap();
+    let ai = address_info(c_fun_add_two as * const ()).unwrap();
+    println!("{:?}", &ai);
+    assert_eq!(&ai.dll_path, lib_path.to_str().unwrap());
+    let os = ai.overlapping_symbol.unwrap();
+    assert_eq!(os.name, "c_fun_add_two");
+    assert_eq!(os.addr, c_fun_add_two as * const ())
+}

--- a/examples/raw_addr_info.rs
+++ b/examples/raw_addr_info.rs
@@ -1,4 +1,3 @@
-extern crate dlopen;
 extern crate libc;
 
 mod commons;

--- a/examples/symbor_api.rs
+++ b/examples/symbor_api.rs
@@ -1,6 +1,3 @@
-extern crate dlopen;
-#[macro_use]
-extern crate dlopen_derive;
 extern crate libc;
 
 mod commons;

--- a/examples/symbor_api.rs
+++ b/examples/symbor_api.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate dlopen_derive;
 extern crate libc;
 
 mod commons;

--- a/src/err.rs
+++ b/src/err.rs
@@ -16,22 +16,27 @@ pub enum Error {
     SymbolGettingError(IoError),
     ///Value of the symbol was null.
     NullSymbol,
+    ///Address could not be matched to a dynamic link library
+    AddrNotMatchingDll
 }
 
 impl ErrorTrait for Error {
     fn description(&self) -> &str {
+        use self::Error::*;
         match self {
-            &Error::NullCharacter(_) => "String had a null character",
-            &Error::OpeningLibraryError(_) => "Could not open library",
-            &Error::SymbolGettingError(_) => "Could not obtain symbol from the library",
-            &Error::NullSymbol => "The symbol is NULL",
+            &NullCharacter(_) => "String had a null character",
+            &OpeningLibraryError(_) => "Could not open library",
+            &SymbolGettingError(_) => "Could not obtain symbol from the library",
+            &NullSymbol => "The symbol is NULL",
+            &AddrNotMatchingDll => "Address does not match any dynamic link library"
         }
     }
 
     fn cause(&self) -> Option<&ErrorTrait> {
+        use self::Error::*;
         match self {
-            &Error::NullCharacter(ref val) => Some(val),
-            &Error::OpeningLibraryError(_) | &Error::SymbolGettingError(_) | &Error::NullSymbol => {
+            &NullCharacter(ref val) => Some(val),
+            &OpeningLibraryError(_) | &SymbolGettingError(_) | &NullSymbol | &AddrNotMatchingDll=> {
                 None
             }
         }
@@ -40,17 +45,18 @@ impl ErrorTrait for Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        use self::Error::*;
         f.write_str(self.description())?;
         match self {
-            &Error::OpeningLibraryError(ref msg) => {
+            &OpeningLibraryError(ref msg) => {
                 f.write_str(": ")?;
                 msg.fmt(f)
             }
-            &Error::SymbolGettingError(ref msg) => {
+            &SymbolGettingError(ref msg) => {
                 f.write_str(": ")?;
                 msg.fmt(f)
             }
-            &Error::NullSymbol | &Error::NullCharacter(_) => Ok(()),
+            &NullSymbol | &NullCharacter(_) | AddrNotMatchingDll=> Ok(()),
         }
     }
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -56,7 +56,7 @@ impl Display for Error {
                 f.write_str(": ")?;
                 msg.fmt(f)
             }
-            &NullSymbol | &NullCharacter(_) | AddrNotMatchingDll=> Ok(()),
+            &NullSymbol | &NullCharacter(_) | &AddrNotMatchingDll=> Ok(()),
         }
     }
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -32,7 +32,7 @@ impl ErrorTrait for Error {
         }
     }
 
-    fn cause(&self) -> Option<&ErrorTrait> {
+    fn cause(&self) -> Option<&dyn ErrorTrait> {
         use self::Error::*;
         match self {
             &NullCharacter(ref val) => Some(val),

--- a/src/err.rs
+++ b/src/err.rs
@@ -17,7 +17,7 @@ pub enum Error {
     ///Value of the symbol was null.
     NullSymbol,
     ///Address could not be matched to a dynamic link library
-    AddrNotMatchingDll
+    AddrNotMatchingDll(IoError)
 }
 
 impl ErrorTrait for Error {
@@ -28,7 +28,7 @@ impl ErrorTrait for Error {
             &OpeningLibraryError(_) => "Could not open library",
             &SymbolGettingError(_) => "Could not obtain symbol from the library",
             &NullSymbol => "The symbol is NULL",
-            &AddrNotMatchingDll => "Address does not match any dynamic link library"
+            &AddrNotMatchingDll(_) => "Address does not match any dynamic link library"
         }
     }
 
@@ -36,7 +36,7 @@ impl ErrorTrait for Error {
         use self::Error::*;
         match self {
             &NullCharacter(ref val) => Some(val),
-            &OpeningLibraryError(_) | &SymbolGettingError(_) | &NullSymbol | &AddrNotMatchingDll=> {
+            &OpeningLibraryError(_) | &SymbolGettingError(_) | &NullSymbol | &AddrNotMatchingDll(_)=> {
                 None
             }
         }
@@ -56,7 +56,7 @@ impl Display for Error {
                 f.write_str(": ")?;
                 msg.fmt(f)
             }
-            &NullSymbol | &NullCharacter(_) | &AddrNotMatchingDll=> Ok(()),
+            &NullSymbol | &NullCharacter(_) | &AddrNotMatchingDll(_)=> Ok(()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,8 @@ At the moment none seems to have any reasonable advantage over the other.
 
 #[cfg(windows)]
 extern crate kernel32;
+#[cfg(windows)]
+extern crate dbghelp;
 #[macro_use]
 extern crate lazy_static;
 #[cfg(any(unix, test))]

--- a/src/raw/common.rs
+++ b/src/raw/common.rs
@@ -3,9 +3,9 @@ use std::ffi::{CStr, CString, OsStr};
 
 //choose the right platform implementation here
 #[cfg(unix)]
-use super::unix::{close_lib, get_sym, open_self, open_lib, Handle};
+use super::unix::{close_lib, get_sym, open_self, open_lib, addr_info, Handle};
 #[cfg(windows)]
-use super::windows::{close_lib, get_sym, open_self, open_lib, Handle};
+use super::windows::{close_lib, get_sym, open_self, open_lib, addr_info, Handle};
 
 use std::mem::{size_of, transmute_copy};
 
@@ -147,4 +147,8 @@ pub struct AddressInfo {
     pub overlapping_symbol_addr: Option<* const ()>,
     pub overlapping_symbol_name: Option<String>,
 
+}
+
+pub fn address_info(addr: * const ()) -> Result<AddressInfo, Error> {
+    addr_info(addr)
 }

--- a/src/raw/common.rs
+++ b/src/raw/common.rs
@@ -139,3 +139,12 @@ impl Drop for Library {
 
 unsafe impl Sync for Library {}
 unsafe impl Send for Library {}
+
+
+pub struct AddressInfo {
+    pub dll_path: String,
+    pub dll_base_addr: * const (),
+    pub overlapping_symbol_addr: Option<* const ()>,
+    pub overlapping_symbol_name: Option<String>,
+
+}

--- a/src/raw/common.rs
+++ b/src/raw/common.rs
@@ -200,7 +200,7 @@ impl AddressInfoObtainer {
     ```
     */
     pub fn obtain(&self, addr: * const ()) -> Result<AddressInfo, Error>{
-        unsafe {addr_info_obtain(addr)}
+        addr_info_obtain(addr)
     }
 }
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -34,4 +34,4 @@ mod windows;
 #[cfg(test)]
 mod tests;
 
-pub use self::common::{Library, AddressInfo, address_info};
+pub use self::common::{Library, AddressInfo, OverlappingSymbol, address_info};

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -34,4 +34,4 @@ mod windows;
 #[cfg(test)]
 mod tests;
 
-pub use self::common::Library;
+pub use self::common::{Library, AddressInfo, address_info};

--- a/src/raw/unix.rs
+++ b/src/raw/unix.rs
@@ -1,6 +1,6 @@
 use super::super::err::Error;
 use std::ffi::{CStr, OsStr};
-use libc::{c_int, c_void, 
+use libc::{c_int, c_void,
     dlclose, dlerror, dlopen, dlsym, dladdr,
     Dl_info, RTLD_LAZY, RTLD_LOCAL
 };
@@ -81,26 +81,43 @@ pub unsafe fn open_lib(name: &OsStr) -> Result<Handle, Error> {
     }
 }
 
+#[inline]
+pub unsafe fn addr_info_init() {}
+#[inline]
+pub unsafe fn addr_info_cleanup() {}
+
+
 use std::mem::MaybeUninit;
 #[inline]
-pub fn addr_info(addr: * const ()) -> Result<AddressInfo, Error>{
+pub fn addr_info_obtain(addr: * const ()) -> Result<AddressInfo, Error>
+{
     // let mut dlinfo: Dl_info = unsafe{uninitialized()};
     let mut dlinfo = MaybeUninit::<Dl_info>::uninit();
-    let result = unsafe {dladdr(addr as * const c_void, dlinfo.as_mut_ptr())};
+    let result = unsafe {
+        dladdr(addr as * const c_void, dlinfo.as_mut_ptr())
+    };
     if result == 0 {
-        Err(Error::AddrNotMatchingDll(IoError::new(ErrorKind::NotFound, String::new())))
+        Err(Error::AddrNotMatchingDll(
+            IoError::new(ErrorKind::NotFound, String::new())))
     } else {
         let dlinfo = unsafe { dlinfo.assume_init() };
-        let os = if dlinfo.dli_saddr.is_null() || dlinfo.dli_sname.is_null() {
+        let os = if dlinfo.dli_saddr.is_null()
+                 || dlinfo.dli_sname.is_null() {
             None
         } else {
             Some(OverlappingSymbol{
                 addr: dlinfo.dli_saddr as * const (),
-                name: CStr::from_ptr(dlinfo.dli_sname).to_string_lossy().into_owned()
+                name: unsafe { 
+                    CStr::from_ptr(dlinfo.dli_sname)
+                        .to_string_lossy().into_owned()
+                },
             })
         };
         Ok(AddressInfo{
-            dll_path: CStr::from_ptr(dlinfo.dli_fname).to_string_lossy().into_owned(),
+            dll_path: unsafe { 
+                CStr::from_ptr(dlinfo.dli_fname)
+                    .to_string_lossy().into_owned()
+            },
             dll_base_addr: dlinfo.dli_fbase as * const (),
             overlapping_symbol: os
         })

--- a/src/raw/unix.rs
+++ b/src/raw/unix.rs
@@ -82,7 +82,7 @@ pub fn addr_info(addr: * const ()) -> Result<AddressInfo, Error>{
     let mut dlinfo: Dl_info = unsafe{uninitialized()};
     let result = unsafe {dladdr(addr as * const c_void, & mut dlinfo)};
     if result == 0 {
-        Err(Error::AddrNotMatchingDll)
+        Err(Error::AddrNotMatchingDll(IoError::new(ErrorKind::NotFound, String::new())))
     } else {
         let os = if dlinfo.dli_saddr.is_null() || dlinfo.dli_sname.is_null() {
             None

--- a/src/raw/unix.rs
+++ b/src/raw/unix.rs
@@ -1,17 +1,21 @@
 use super::super::err::Error;
 use std::ffi::{CStr, OsStr};
-use libc::{c_int, c_void, dlclose, dlerror, dlopen, dlsym, dladdr, Dl_info, RTLD_LAZY, RTLD_LOCAL};
+use libc::{c_int, c_void, 
+    dlclose, dlerror, dlopen, dlsym, dladdr,
+    Dl_info, RTLD_LAZY, RTLD_LOCAL
+};
 use std::ptr::{null, null_mut};
 use std::os::unix::ffi::OsStrExt;
 use std::io::{Error as IoError, ErrorKind};
-use std::mem::uninitialized;
+// use std::mem::uninitialized;
 use super::common::{AddressInfo, OverlappingSymbol};
 
 const DEFAULT_FLAGS: c_int = RTLD_LOCAL | RTLD_LAZY;
 
 use std::sync::Mutex;
 
-// calls to dlerror are not thread unsafe. Therefore we need to guard each call with a mutex
+// calls to dlerror are not thread-safe, so we guard them
+// with a mutex
 
 lazy_static! {
     static ref DLERROR_MUTEX: Mutex<()> = Mutex::new(());
@@ -25,7 +29,7 @@ pub unsafe fn get_sym(handle: Handle, name: &CStr) -> Result<*mut (), Error> {
     //clear the dlerror in order to be able to distinguish between NULL pointer and error
     let _ = dlerror();
     let symbol = dlsym(handle, name.as_ptr());
-    //This can be either error or just the library has a NULl pointer - legal
+    //This can be either error or just the library has a NULL pointer - legal
     if symbol.is_null() {
         let msg = dlerror();
         if !msg.is_null() {
@@ -77,13 +81,16 @@ pub unsafe fn open_lib(name: &OsStr) -> Result<Handle, Error> {
     }
 }
 
+use std::mem::MaybeUninit;
 #[inline]
 pub fn addr_info(addr: * const ()) -> Result<AddressInfo, Error>{
-    let mut dlinfo: Dl_info = unsafe{uninitialized()};
-    let result = unsafe {dladdr(addr as * const c_void, & mut dlinfo)};
+    // let mut dlinfo: Dl_info = unsafe{uninitialized()};
+    let mut dlinfo = MaybeUninit::<Dl_info>::uninit();
+    let result = unsafe {dladdr(addr as * const c_void, dlinfo.as_mut_ptr())};
     if result == 0 {
         Err(Error::AddrNotMatchingDll(IoError::new(ErrorKind::NotFound, String::new())))
     } else {
+        let dlinfo = unsafe { dlinfo.assume_init() };
         let os = if dlinfo.dli_saddr.is_null() || dlinfo.dli_sname.is_null() {
             None
         } else {

--- a/src/raw/windows.rs
+++ b/src/raw/windows.rs
@@ -9,7 +9,7 @@ use std::ptr::{null, null_mut};
 use std::ffi::{CStr, OsStr, OsString};
 use std::sync::Mutex;
 use super::common::AddressInfo;
-use winapi::shared::ntdef::WCHAR;
+use winapi::WCHAR;
 use std::mem::uninitialized;
 
 
@@ -163,7 +163,7 @@ pub unsafe fn open_lib(name: &OsStr) -> Result<Handle, Error> {
 pub fn addr_info(addr: * const ()) -> Result<AddressInfo, Error>{
     let process_handle = unsafe{kernel32::GetCurrentProcess()};
     let module_base = unsafe{dbghelp::SymGetModuleBase64(process_handle, addr as u64)};
-    let mut buffer: [WCHAR; kernel32::PATH_MAX] = unsafe{uninitialized()};
+    let mut buffer: [WCHAR; PATH_MAX] = unsafe{uninitialized()};
 
     let path_len = unsafe{kernel32::GetModuleFileNameW(null(), buffer.as_mut_ptr(), PATH_MAX)};
     if path_len == 0 {
@@ -172,7 +172,7 @@ pub fn addr_info(addr: * const ()) -> Result<AddressInfo, Error>{
 
     Ok({
         AddressInfo{
-            dll_path: OsString::from_wide(buffer[0..path_len])..to_string_lossy().into_owned(),
+            dll_path: OsString::from_wide(buffer[0..path_len]).to_string_lossy().into_owned(),
             dll_base_addr: module_base as * const (),
             overlapping_symbol_name: None,
             overlapping_symbol_addr: None

--- a/tests/raw.rs
+++ b/tests/raw.rs
@@ -2,7 +2,7 @@
 extern crate const_cstr;
 extern crate dlopen;
 extern crate libc;
-use dlopen::raw::Library;
+use dlopen::raw::{Library, address_info};
 use libc::{c_char, c_int};
 use std::ffi::CStr;
 
@@ -56,4 +56,17 @@ fn open_play_close_raw() {
     assert_eq!(converted, "Hi!");
 
     ::std::mem::forget(lib);
+}
+
+#[test]
+fn example_address_info(){
+    let lib_path = example_lib_path();
+    let lib = Library::open(&lib_path).expect("Could not open library");
+    let c_fun_add_two: unsafe extern "C" fn(c_int) -> c_int =
+        unsafe { lib.symbol("c_fun_add_two") }.unwrap();
+    let ai = address_info(c_fun_add_two as * const ()).unwrap();
+    assert_eq!(&ai.dll_path, lib_path.to_str().unwrap());
+    let os = ai.overlapping_symbol.unwrap();
+    assert_eq!(os.name, "c_fun_add_two");
+    assert_eq!(os.addr, c_fun_add_two as * const ())
 }


### PR DESCRIPTION
## Preamble
Hi there are a bunch of changes in this set of patches.
I tried to ensure that each commit was addressing one topic.  

The changes included are:

1. library updates:
   * lazy_static -> 1.3.0
   * libc -> 0.2.62

2. dev dependencies updates:
  * const-cstr -> 0.3.0
  * regex -> 1.2.1
  * serde 1.0.99 (with derive feature)
  * serde_json 1.0.40

3. README.md linted for markdown

4. example_lib_path() in *tests* and *examples* refactored to use `manifest.workspace_root` instead of `CARGO_MANIFEST_DIR` this ensures that if the project is added to an existing workspace that the tests and examples will run properly.

5. removed `extern crate dlopen;` from a bunch of places. 
    * TODO: remove all `extern crate` references 

6. Fixed 2018 stuff like replacing `&ErrorTrait` with `&dyn ErrorTrait`

7. Removed undefined usage of `std::mem::uninitialized` which is deprecated and replaced it with `std::mem::MaybeUninit` -- have a look at the changes to addr_info_*, the recent changes you made may be unnecessary.
  * TODO: ensure that this is tied to Drop handling for the Library

8. TODO: There are a bunch of `panic!`s in the library core code, and a library shouldn't panic in any case. I'll be submitting a couple of patches around that.
---

In addition, I have started formating the code to fit 80 chars :-) because, https://youtu.be/ZsHMHukIlJY.

