### PR TITLE
Markdown and Typo Fix

### DIFF
--- a/rust-dlopen-derive/src/wrapper.rs
+++ b/rust-dlopen-derive/src/wrapper.rs
@@ -54,7 +54,7 @@ fn field_to_tokens(field: &Field) -> syn::export::TokenStream2 {
         } else {
             normal_field(field)
         },
-        _ => panic!("Only bare functions, references an pointers are allowed in structures implementing WrapperApi trait")
+        _ => panic!("Only bare functions, references and pointers are allowed in structures implementing WrapperApi trait")
     }
 }
 

--- a/src/symbor/container.rs
+++ b/src/symbor/container.rs
@@ -13,7 +13,7 @@ structure has two objects and one of the objects has a reference to the second o
 Normally you can't put `Library` and a structure that implements `SymBorApi` into one structure.
 This structure allows you to do it.
 
-#Example
+# Example
 
 ```no_run
 #[macro_use]

--- a/src/symbor/library.rs
+++ b/src/symbor/library.rs
@@ -23,7 +23,7 @@ dangling symbols is prevented.
 * `ptr_or_null()` and `ptr_or_null_mut()` - for obtaining pointers if you accept null values of
 pointers (in 99% of cases you should rather use previously mentioned methods).
 
-#Example
+# Example
 
 ```no_run
 extern crate dlopen;

--- a/src/symbor/mod.rs
+++ b/src/symbor/mod.rs
@@ -5,7 +5,7 @@ It is based on symbol borrowing mechanism and supports automatic loading of symb
 This API uses Rust borrowing mechanism to prevent problems with dangling symbols
 that take place when the library gets closed but the symbols still exist and are used.
 
-#Example of a dangling symbol prevention
+# Example of a dangling symbol prevention
 ```no_run
 extern crate dlopen;
 use dlopen::symbor::Library;
@@ -66,7 +66,7 @@ Unfortunately in Rust it is not possible to create an API for dynamic link libra
 be 100% safe. This API aims to be 99% safe by providing zero cost wrappers around raw symbols.
 However it is possible to make a mistake if you dereference safe wrappers into raw symbols.
 
-#Example of a mistake - dangling symbol
+# Example of a mistake - dangling symbol
 
 ```no_run
 extern crate dlopen;

--- a/src/wrapper/api.rs
+++ b/src/wrapper/api.rs
@@ -29,7 +29,7 @@ Wrappers are not generated only for:
 * Variadic functions. Rust doesn't have any mechanism that allows creating safe wrappers around
     them. You need to handle them manually.
 
-#Example
+# Example
 
 ```no_run
 #[macro_use]

--- a/src/wrapper/container.rs
+++ b/src/wrapper/container.rs
@@ -11,7 +11,7 @@ Keeping both library and its symbols together makes it safe to use it because sy
 together with the library. `Container` also doesn't have any external lifetimes - this makes it
 easy to use `Container` inside structures.
 
-#Example
+# Example
 
 ```no_run
 #[macro_use]

--- a/src/wrapper/mod.rs
+++ b/src/wrapper/mod.rs
@@ -8,7 +8,7 @@ User of API does not have direct access to raw symbols and therefore symbols can
 Symbols and library handle are kept in one `Container` structure and therefore both the the library
 and symbols get released at the same time.
 
-#Example
+# Example
 
 ```no_run
 #[macro_use]
@@ -40,7 +40,7 @@ be 100% safe. This API aims to be 99% safe by providing zero cost functional wra
 raw symbols. However it is possible to make a mistake if you create API as a standalone object
 (not in container):
 
-#Example of a mistake - dangling symbol
+# Example of a mistake - dangling symbol
 
 ```no_run
 #[macro_use]

--- a/src/wrapper/optional.rs
+++ b/src/wrapper/optional.rs
@@ -12,7 +12,7 @@ of those versions have broader API than others. This structure allows you to use
 same time - one obligatory and one optional. If symbols of the optional API are found in the
 library, the optional API gets loaded. Otherwise the `optional()` method will return `None`.
 
-#Example
+# Example
 
 ```no_run
 #[macro_use]


### PR DESCRIPTION
Should be able to close #29 and close #30. I don't know if there's more markdown errors, only grepped for the examples.