### PR TITLE
Fine-tune the Ordering for the atomic usages

### DIFF
--- a/src/raw/windows.rs
+++ b/src/raw/windows.rs
@@ -65,13 +65,13 @@ enum ErrorModeGuard {
 
 impl ErrorModeGuard {
     fn new() -> Result<ErrorModeGuard, IoError> {
-        if !USE_ERRORMODE.load(Ordering::Acquire) {
+        if !USE_ERRORMODE.load(Ordering::Relaxed) {
             let mut previous: DWORD = 0;
             if unsafe { SetThreadErrorMode(ERROR_MODE, &mut previous) } == 0 {
                 //error. On some systems SetThreadErrorMode may not be implemented
                 let error = unsafe { GetLastError() };
                 if error == ERROR_CALL_NOT_IMPLEMENTED {
-                    USE_ERRORMODE.store(true, Ordering::Release);
+                    USE_ERRORMODE.store(true, Ordering::Relaxed);
                 } else {
                     //this is an actual error
                     //SetErrorMode never fails. Shouldn't we use it now?


### PR DESCRIPTION
`SeqCst` is overly restrictive. I believe that the ordering can be appropriately modified.
I think that `USE_ERRORMODE` is merely signal for multithreading purposes and do not synchronize with other locals. Therefore, using `Relaxed` ordering should suffice.

https://github.com/szymonwieloch/rust-dlopen/blob/f9fed7168dfdcfd682a6c409595d4e2430b2dd2d/src/raw/windows.rs#L68-L79